### PR TITLE
feat: autosave timeline on view switch

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -14,17 +14,22 @@
     EventsOn,
     WindowSetTitle,
   } from "../wailsjs/runtime/runtime";
-  import { ResetTimeline } from "../wailsjs/go/main/App";
+  import { ResetTimeline, SaveTimeline } from "../wailsjs/go/main/App";
   import { onDestroy } from "svelte";
   const { route, setRoute } = router;
   const { isProcessingVid } = exportOptionsStore;
   const { resetVideo } = videoStore;
   const { resetVideoFiles } = videoFiles;
 
-  function cleanupProjectWorkspace() {
+  async function cleanupProjectWorkspace() {
     resetVideoFiles();
     resetVideo();
-    ResetTimeline();
+    try {
+      await SaveTimeline();
+      await ResetTimeline();
+    } catch (err) {
+      console.log(err);
+    }
     WindowSetTitle("Gahara");
   }
 
@@ -36,6 +41,7 @@
             cleanupProjectWorkspace();
             break;
           case "export":
+            SaveTimeline().catch(console.log);
             WindowSetTitle(`Export - ${$projectName}`);
         }
         setRoute(to);

--- a/frontend/src/VideoLayout.svelte
+++ b/frontend/src/VideoLayout.svelte
@@ -6,7 +6,6 @@
     LoadProjectFiles,
     SaveTimeline,
     SaveProjectFiles,
-    ResetTimeline,
     DeleteRIDReferences,
     DeleteProjectFile,
     EnableVideoMenus,
@@ -164,10 +163,6 @@
             <button
               class="bg-gblue0 rounded-lg px-2 py-1 border-2 border-white flex items-center gap-2 hover:bg-gblue transition ease-in-out duration-200"
               on:click={() => {
-                resetVideoFiles();
-                resetVideo();
-                ResetTimeline();
-                WindowSetTitle("Gahara");
                 setRoute("main");
               }}
             >

--- a/frontend/src/components/VideoPlayer.svelte
+++ b/frontend/src/components/VideoPlayer.svelte
@@ -69,7 +69,7 @@
   }
 
   function handleStop() {
-    video.pause();
+    if (video) video.pause();
     $currentTime = $videoNode ? $videoNode.start : 0;
   }
 


### PR DESCRIPTION
## Description
This PR autosaves the timeline whenever the view is switched from the video view, either to export or to project selection.
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this? (check all applicable)

- [x] 💡 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents
closes #37 
<!--
Please use this format link issue numbers: Fixes #123, Closes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## [optional] What gif best describes this PR or how it makes you feel?

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.

  Before submitting a Pull Request, please ensure you've done the following:
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
