### PR TITLE
fix: get video duration from ffmpeg

### DIFF
--- a/app.go
+++ b/app.go
@@ -207,7 +207,17 @@ func (a *App) ReadProjectWorkspace() ([]Video, error) {
 			if !video.IsValidExtension(filepath.Ext(project.Name())) {
 				continue
 			}
-			projectFiles = append(projectFiles, Video{Name: strings.Split(project.Name(), ".")[0], Extension: filepath.Ext(project.Name()), FilePath: a.config.ProjectDir})
+
+			duration, err := getVideoDuration(video.ProcessingOpts{
+				Filename:    strings.Split(project.Name(), ".")[0],
+				VideoFormat: filepath.Ext(project.Name()),
+				InputPath:   a.config.ProjectDir,
+			})
+			if err != nil {
+				wruntime.LogError(a.ctx, fmt.Sprintf("could not check video duration: %s", err.Error()))
+				continue
+			}
+			projectFiles = append(projectFiles, Video{Name: strings.Split(project.Name(), ".")[0], Extension: filepath.Ext(project.Name()), FilePath: a.config.ProjectDir, Duration: duration})
 		}
 	}
 

--- a/ffmpegbuilder/ffmpegbuilder.go
+++ b/ffmpegbuilder/ffmpegbuilder.go
@@ -63,6 +63,8 @@ type OutputParams struct {
 	// MovFlags: -movflags in ffmpeg, mov, mp4, and ismv support fragmentation. The metadata about all packets is stored in one location,
 	// but it can be moved at the start for better playback (+faststart)
 	MovFlags string
+	// NullOutput: -f null -  in ffmpeg (used to check info only)
+	NullOutput string
 }
 
 func NewDefaultFFmpegBuilder() *FFmpegBuilder {
@@ -113,8 +115,18 @@ func (f *FFmpegBuilder) WithStatsPeriod(statsPeriod string) *FFmpegBuilder {
 	return f
 }
 
+func (f *FFmpegBuilder) WithVerbose(verbose string) *FFmpegBuilder {
+	f.PreInputParams.VerboseMode = ""
+	return f
+}
+
 func (f *FFmpegBuilder) WithCodec(codec string) *FFmpegBuilder {
 	f.OutputParams.Codec = codec
+	return f
+}
+
+func (f *FFmpegBuilder) WithNullOutput() *FFmpegBuilder {
+	f.OutputParams.NullOutput = "-f null -"
 	return f
 }
 
@@ -258,6 +270,9 @@ func (f *FFmpegBuilder) BuildQuery() (string, error) {
 	}
 
 	// Append output parameters
+	if f.OutputParams.NullOutput != "" {
+		cmd.WriteString(fmt.Sprintf("%s ", f.OutputParams.NullOutput))
+	}
 	if f.OutputParams.Duration != 0 {
 		cmd.WriteString(fmt.Sprintf("-t %.4f ", f.OutputParams.Duration))
 	}

--- a/ffmpegbuilder/query.go
+++ b/ffmpegbuilder/query.go
@@ -5,14 +5,31 @@ import (
 	"github.com/k1nho/gahara/internal/video"
 )
 
+func CheckVideoDuration(userOpts video.ProcessingOpts) (string, error) {
+	input := GetFullInputPath(userOpts)
+
+	query, err := NewDefaultFFmpegBuilder().WithInputs(input).
+		WithNullOutput().WithVerbose("").BuildQuery()
+	if err != nil {
+		return "", err
+	}
+	return query, nil
+}
+
 // CreateProxyFileQuery: creates a proxy file for a video
 func CreateProxyFileQuery(userOpts video.ProcessingOpts, format string) (string, error) {
 	input := GetFullInputPath(userOpts)
 	userOpts.VideoFormat = format
 	output := GetFullOutputPath(userOpts)
 
-	query, err := NewDefaultFFmpegBuilder().WithInputs(input).WithCodec("copy").
-		WithOutputs(output).BuildQuery()
+	querybuilder := NewDefaultFFmpegBuilder().WithInputs(input).WithCodec("copy").
+		WithOutputs(output)
+
+	if err := querybuilder.validateProxyFileCreationQuery(); err != nil {
+		return "", err
+	}
+
+	query, err := querybuilder.BuildQuery()
 	if err != nil {
 		return "", err
 	}
@@ -20,7 +37,7 @@ func CreateProxyFileQuery(userOpts video.ProcessingOpts, format string) (string,
 	return query, nil
 }
 
-// GenerateThumbnailQuery: generate a thumbnail from a video
+// CreateThumbnailQuery: generates a thumbnail taking the 1 frame of a video
 func CreateThumbnailQuery(userOpts video.ProcessingOpts, format string) (string, error) {
 	input := GetFullInputPath(userOpts)
 	userOpts.VideoFormat = format

--- a/ffmpegbuilder/validate.go
+++ b/ffmpegbuilder/validate.go
@@ -38,3 +38,17 @@ func (f *FFmpegBuilder) validateLosslessCutQuery() error {
 	}
 	return nil
 }
+
+func (f *FFmpegBuilder) validateProxyFileCreationQuery() error {
+	if len(f.Inputs) != 1 {
+		return fmt.Errorf("no input stream(s) provided")
+	}
+	if len(f.Outputs) != 1 {
+		return fmt.Errorf("no output stream(s) provided")
+	}
+
+	if f.OutputParams.Codec != "copy" {
+		return fmt.Errorf("codec must be copy. No re-encoding needed for proxy")
+	}
+	return nil
+}

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1,20 +1,50 @@
 <script lang="ts">
   import VideoLayout from "./VideoLayout.svelte";
   import MainMenuLayout from "./MainMenuLayout.svelte";
-  import { exportOptionsStore, router } from "./stores";
+  import {
+    exportOptionsStore,
+    router,
+    videoFiles,
+    videoStore,
+    projectName,
+  } from "./stores";
   import ExportMenuLayout from "./ExportMenuLayout.svelte";
-  import { EventsOff, EventsOn } from "../wailsjs/runtime/runtime";
+  import {
+    EventsOff,
+    EventsOn,
+    WindowSetTitle,
+  } from "../wailsjs/runtime/runtime";
+  import { ResetTimeline } from "../wailsjs/go/main/App";
   import { onDestroy } from "svelte";
   const { route, setRoute } = router;
   const { isProcessingVid } = exportOptionsStore;
+  const { resetVideo } = videoStore;
+  const { resetVideoFiles } = videoFiles;
+
+  function cleanupProjectWorkspace() {
+    resetVideoFiles();
+    resetVideo();
+    ResetTimeline();
+    WindowSetTitle("Gahara");
+  }
 
   EventsOn("evt_change_route", (to: string) => {
     switch ($route) {
       case "video":
+        switch (to) {
+          case "main":
+            cleanupProjectWorkspace();
+            break;
+          case "export":
+            WindowSetTitle(`Export - ${$projectName}`);
+        }
         setRoute(to);
         break;
       case "export":
-        if (!$isProcessingVid) setRoute(to);
+        if (!$isProcessingVid) {
+          WindowSetTitle($projectName);
+          setRoute(to);
+        }
     }
   });
 

--- a/frontend/src/components/SearchList.svelte
+++ b/frontend/src/components/SearchList.svelte
@@ -12,8 +12,7 @@
   } = toolingStore;
   const { addVideoToTrack } = trackStore;
   const { searchFiles } = videoFiles;
-  const { source, setVideoSrc, setCurrentTime, getDuration, viewVideo } =
-    videoStore;
+  const { source, setVideoSrc, setCurrentTime, viewVideo } = videoStore;
 
   let searchTerm = "";
   let searchIdx = -1;
@@ -44,14 +43,11 @@
       if (searchIdx >= 0 && searchIdx < searchList.length) {
         viewVideo(searchList[searchIdx]);
 
-        const videoDuration = getDuration();
-        if (videoDuration === 0) return;
-
         InsertInterval(
           $source,
           searchList[searchIdx].name,
           0,
-          videoDuration,
+          searchList[searchIdx].duration,
           $videoNodePos,
         )
           .then((tVideo) => {

--- a/frontend/src/lib/dnd.ts
+++ b/frontend/src/lib/dnd.ts
@@ -1,5 +1,5 @@
 import { draggedVideo, trackStore, videoStore, toolingStore } from "../stores";
-import type { video, main } from "../../wailsjs/go/models";
+import type { main } from "../../wailsjs/go/models";
 import { InsertInterval } from "../../wailsjs/go/main/App";
 
 export function draggable(node: HTMLDivElement, data: main.Video) {
@@ -72,7 +72,7 @@ export function dropzone(node: HTMLDivElement, opts) {
       videoID,
       draggedVideo.value().name,
       0,
-      videoStore.getDuration(),
+      draggedVideo.value().duration,
       0,
     )
       .then((tVideo) => {

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -36,6 +36,8 @@ export function GetTrackDuration():Promise<number>;
 
 export function InsertInterval(arg1:string,arg2:string,arg3:number,arg4:number,arg5:number):Promise<video.VideoNode>;
 
+export function LoadProjectFiles():Promise<Array<main.Video>>;
+
 export function LoadTimeline():Promise<video.Timeline>;
 
 export function OpenFile(arg1:string):Promise<void>;
@@ -49,6 +51,8 @@ export function RemoveInterval(arg1:number):Promise<void>;
 export function RenameVideoNode(arg1:number,arg2:string):Promise<void>;
 
 export function ResetTimeline():Promise<void>;
+
+export function SaveProjectFiles(arg1:Array<main.Video>):Promise<void>;
 
 export function SaveTimeline():Promise<void>;
 

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -66,6 +66,10 @@ export function InsertInterval(arg1, arg2, arg3, arg4, arg5) {
   return window['go']['main']['App']['InsertInterval'](arg1, arg2, arg3, arg4, arg5);
 }
 
+export function LoadProjectFiles() {
+  return window['go']['main']['App']['LoadProjectFiles']();
+}
+
 export function LoadTimeline() {
   return window['go']['main']['App']['LoadTimeline']();
 }
@@ -92,6 +96,10 @@ export function RenameVideoNode(arg1, arg2) {
 
 export function ResetTimeline() {
   return window['go']['main']['App']['ResetTimeline']();
+}
+
+export function SaveProjectFiles(arg1) {
+  return window['go']['main']['App']['SaveProjectFiles'](arg1);
 }
 
 export function SaveTimeline() {

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -1,9 +1,11 @@
 export namespace main {
 	
 	export class Video {
+	    id: string;
 	    name: string;
 	    extension: string;
 	    filepath: string;
+	    duration: number;
 	
 	    static createFrom(source: any = {}) {
 	        return new Video(source);
@@ -11,9 +13,11 @@ export namespace main {
 	
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.id = source["id"];
 	        this.name = source["name"];
 	        this.extension = source["extension"];
 	        this.filepath = source["filepath"];
+	        this.duration = source["duration"];
 	    }
 	}
 

--- a/internal/video/video.go
+++ b/internal/video/video.go
@@ -70,6 +70,8 @@ const (
 	EVT_INTERVAL_CUT = "intervalCut"
 	// EVT_SLICE_CUT: slice cut event
 	EVT_SLICE_CUT = "evt_slice_cut"
+	// EVT_DURATION_EXTRACTED: duration extracted from ffmpeg execution
+	EVT_DURATION_EXTRACTED = "evt_duration_extracted"
 	// EVT_ENCODING_PROGRESS: encoding progress event
 	EVT_ENCODING_PROGRESS = "evt_encoding_progress"
 	// EVT_EXPORT_MSG: message for exporting a video events
@@ -124,6 +126,12 @@ const (
 	PRESET_MEDIUM = "medium"
 	// PRESET_FAST: fast preset provides faster encoding speed at the tradeoff of better compression
 	PRESET_FAST = "fast"
+	// OUT_TIME_US: out_time_us term to monitor in ffmpeg execution
+	OBV_OUT_TIME_US = "out_time_us"
+	// OUT_TIME: out_time term to monitor in ffmpeg execution
+	OBV_OUT_TIME = "out_time"
+	// Duration: duration term to monitor in ffmpeg execution
+	OBV_DURATION = "Duration"
 )
 
 type VideoNode struct {
@@ -342,9 +350,6 @@ func FormatTime(seconds float64) string {
 }
 
 func (p *ProcessingOpts) ValidateRequiredFields(queryType string) error {
-	if p.OutputPath == "" {
-		return fmt.Errorf("output path was not provided")
-	}
 	if p.Filename == "" {
 		return fmt.Errorf("filename was not provided")
 	}
@@ -359,12 +364,21 @@ func (p *ProcessingOpts) ValidateRequiredFields(queryType string) error {
 
 	switch queryType {
 	case QUERY_FILTERGRAPH:
+		if p.OutputPath == "" {
+			return fmt.Errorf("output path was not provided")
+		}
 		if !p.isCodecCompatible() {
 			return fmt.Errorf("codec is not compatible with %s format", p.VideoFormat)
 		}
 	case QUERY_LOSSLESS_CUT:
+		if p.OutputPath == "" {
+			return fmt.Errorf("output path was not provided")
+		}
 
 	case QUERY_CREATE_PROXY_FILE, QUERY_CREATE_THUMBNAIL:
+		if p.OutputPath == "" {
+			return fmt.Errorf("output path was not provided")
+		}
 		if p.InputPath == "" {
 			return fmt.Errorf("input path was not provided")
 		}


### PR DESCRIPTION
## Description
This PR fixes video duration bugs produced by client side cross check using video player mounts. Now the filesystem uses ffmpeg to get the video durations for uploaded clips as well as to set it for uploading clips.
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this? (check all applicable)

- [ ] 💡 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents
closes #42 
<!--
Please use this format link issue numbers: Fixes #123, Closes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->



## [optional] What gif best describes this PR or how it makes you feel?

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.

  Before submitting a Pull Request, please ensure you've done the following:
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
