### PR TITLE
feat: unmark/mark clips as lossless for export

### DIFF
--- a/app.go
+++ b/app.go
@@ -303,9 +303,16 @@ func (a *App) EnableVideoMenus() {
 	timelineMenu.AddText("Rename Clip", keys.CmdOrCtrl("r"), func(cd *menu.CallbackData) {
 		wruntime.EventsEmit(a.ctx, video.EVT_OPEN_RENAME_CLIP_MODAL)
 	})
-	timelineMenu.AddText("Mark/Unmark Lossless Export", keys.Key("m"), func(cd *menu.CallbackData) {
+	timelineMenu.AddText("Mark/Unmark Clip (Lossless Export)", keys.Key("m"), func(cd *menu.CallbackData) {
 		wruntime.EventsEmit(a.ctx, video.EVT_TOGGLE_LOSSLESS)
 	})
+	timelineMenu.AddText("Mark All Clips (Lossless Export)", keys.Shift("m"), func(cd *menu.CallbackData) {
+		wruntime.EventsEmit(a.ctx, video.EVT_MARK_ALL_LOSSLESS)
+	})
+	timelineMenu.AddText("Unmark All Clips (Lossless Export)", keys.Shift("u"), func(cd *menu.CallbackData) {
+		wruntime.EventsEmit(a.ctx, video.EVT_UNMARK_ALL_LOSSLESS)
+	})
+
 	timelineMenu.AddText("Change Project", keys.Shift("b"), func(cd *menu.CallbackData) {
 		wruntime.EventsEmit(a.ctx, video.EVT_CHANGE_ROUTE, "main")
 	})

--- a/frontend/src/components/Timeline.svelte
+++ b/frontend/src/components/Timeline.svelte
@@ -18,6 +18,8 @@
     InsertInterval,
     RenameVideoNode,
     ToggleLossless,
+    MarkAllLossless,
+    UnmarkAllLossless,
   } from "../../wailsjs/go/main/App";
   import RenameIcon from "../icons/RenameIcon.svelte";
   import SearchList from "../components/SearchList.svelte";
@@ -69,6 +71,8 @@
     setTrackTime,
     renameClipInTrack,
     toggleLosslessMarkofClip,
+    markAllLossless,
+    unmarkAllLossless,
     resetTrackStore,
   } = trackStore;
 
@@ -400,6 +404,25 @@
         .catch((err) => setActionMsg(err));
     }
   });
+
+  EventsOn("evt_mark_all_lossless", () => {
+    MarkAllLossless()
+      .then(() => {
+        markAllLossless();
+        setActionMsg("-- MARKED CLIPS --");
+      })
+      .catch((err) => setActionMsg(err));
+  });
+
+  EventsOn("evt_unmark_all_lossless", () => {
+    UnmarkAllLossless()
+      .then(() => {
+        unmarkAllLossless();
+        setActionMsg("-- UNMARKED CLIPS --");
+      })
+      .catch((err) => setActionMsg(err));
+  });
+
   onDestroy(() => {
     EventsOff(
       "evt_open_rename_clip_modal",
@@ -411,6 +434,8 @@
       "evt_zoom_timeline",
       "evt_saved_timeline",
       "evt_toggle_lossless",
+      "evt_mark_all_lossless",
+      "evt_unmark_all_lossless",
     );
     resetTrackStore();
     resetToolingStore();

--- a/frontend/src/stores.ts
+++ b/frontend/src/stores.ts
@@ -234,6 +234,26 @@ function createTracksStore() {
     });
   };
 
+  const markAllLossless = () => {
+    update((tracks) => {
+      if (!tracks[0]) return tracks;
+      for (let track of tracks[0]) {
+        track.losslessexport = true;
+      }
+      return tracks;
+    });
+  };
+
+  const unmarkAllLossless = () => {
+    update((tracks) => {
+      if (!tracks[0]) return tracks;
+      for (let track of tracks[0]) {
+        track.losslessexport = false;
+      }
+      return tracks;
+    });
+  };
+
   const resetTrackStore = () => {
     set([]);
     setTrackTime(0);
@@ -250,6 +270,8 @@ function createTracksStore() {
     removeRIDReferencesFromTrack,
     renameClipInTrack,
     toggleLosslessMarkofClip,
+    markAllLossless,
+    unmarkAllLossless,
     trackDuration,
     resetTrackStore,
   };

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -40,6 +40,8 @@ export function LoadProjectFiles():Promise<Array<main.Video>>;
 
 export function LoadTimeline():Promise<video.Timeline>;
 
+export function MarkAllLossless():Promise<void>;
+
 export function OpenFile(arg1:string):Promise<void>;
 
 export function ReadGaharaWorkspace():Promise<Array<string>>;
@@ -63,3 +65,5 @@ export function SetProjectDirectory(arg1:string):Promise<void>;
 export function SplitInterval(arg1:string,arg2:number,arg3:number,arg4:number):Promise<Array<video.VideoNode>>;
 
 export function ToggleLossless(arg1:number):Promise<void>;
+
+export function UnmarkAllLossless():Promise<void>;

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -74,6 +74,10 @@ export function LoadTimeline() {
   return window['go']['main']['App']['LoadTimeline']();
 }
 
+export function MarkAllLossless() {
+  return window['go']['main']['App']['MarkAllLossless']();
+}
+
 export function OpenFile(arg1) {
   return window['go']['main']['App']['OpenFile'](arg1);
 }
@@ -120,4 +124,8 @@ export function SplitInterval(arg1, arg2, arg3, arg4) {
 
 export function ToggleLossless(arg1) {
   return window['go']['main']['App']['ToggleLossless'](arg1);
+}
+
+export function UnmarkAllLossless() {
+  return window['go']['main']['App']['UnmarkAllLossless']();
 }

--- a/internal/video/video.go
+++ b/internal/video/video.go
@@ -52,6 +52,10 @@ const (
 	EVT_INSERTCLIP_EDIT = "evt_insertclip_edit"
 	//EVT_TOGGLE_LOSSLESS: toggles the video node status to be exported as lossless
 	EVT_TOGGLE_LOSSLESS = "evt_toggle_lossless"
+	// EVT_MARK_ALL_LOSSLESS: marks all the video nodes as lossless
+	EVT_MARK_ALL_LOSSLESS = "evt_mark_all_lossless"
+	//EVT_UNMARK_ALL_LOSSLESS: umarks all the video nodes marked as lossless
+	EVT_UNMARK_ALL_LOSSLESS = "evt_unmark_all_lossless"
 	// EVT_EXECUTE_EDIT: execute the current edit
 	EVT_EXECUTE_EDIT = "evt_execute_edit"
 	// EVT_PLAY_TRACK: plays the clips on the track (starting from current pos and clip time)
@@ -239,6 +243,30 @@ func (tl *Timeline) ToggleLossless(pos int) error {
 		return fmt.Errorf("there are no video clips to mark")
 	}
 	tl.VideoNodes[pos].LosslessExport = !tl.VideoNodes[pos].LosslessExport
+	return nil
+}
+
+func (tl *Timeline) MarkAllLossless() error {
+	if len(tl.VideoNodes) == 0 {
+		return fmt.Errorf("there are no video clips to mark")
+	}
+
+	for i := range tl.VideoNodes {
+		tl.VideoNodes[i].LosslessExport = true
+	}
+
+	return nil
+}
+
+func (tl *Timeline) UnmarkAllLossless() error {
+	if len(tl.VideoNodes) == 0 {
+		return fmt.Errorf("there are no video clips to mark")
+	}
+
+	for i := range tl.VideoNodes {
+		tl.VideoNodes[i].LosslessExport = false
+	}
+
 	return nil
 }
 

--- a/video.go
+++ b/video.go
@@ -346,6 +346,14 @@ func (a *App) ToggleLossless(pos int) error {
 	return a.Timeline.ToggleLossless(pos)
 }
 
+func (a *App) MarkAllLossless() error {
+	return a.Timeline.MarkAllLossless()
+}
+
+func (a *App) UnmarkAllLossless() error {
+	return a.Timeline.UnmarkAllLossless()
+}
+
 // ResetTimeline: cleanup timeline state in memory
 func (a *App) ResetTimeline() {
 	a.Timeline = video.NewTimeline()


### PR DESCRIPTION
## Description
This PR implements accelerators to mark/unmark all clips in the timeline as lossless to export.
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this? (check all applicable)

- [x] 💡 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents
closes #32 
<!--
Please use this format link issue numbers: Fixes #123, Closes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## [optional] What gif best describes this PR or how it makes you feel?

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.

  Before submitting a Pull Request, please ensure you've done the following:
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
